### PR TITLE
Add option to skip writing json

### DIFF
--- a/exp/extract.jl
+++ b/exp/extract.jl
@@ -12,6 +12,10 @@ using OPFGenerator
 if abspath(PROGRAM_FILE) == @__FILE__
     configfile = ARGS[1]
     config = TOML.parsefile(configfile)
+    if get(config, "no_json", false)
+        @info "Skipping JSON to HDF5 conversion since `no_json` is `true` in the config."
+        exit()
+    end
     batch_size = parse(Int, get(ARGS, 2, "1024"))
     OPFGenerator.parse_jsons(config;
         show_progress=false,

--- a/exp/sampler.jl
+++ b/exp/sampler.jl
@@ -85,8 +85,14 @@ if abspath(PROGRAM_FILE) == @__FILE__
     smin = parse(Int, ARGS[2])
     smax = parse(Int, ARGS[3])
 
-    resdir_json = joinpath(config["export_dir"], "res_json")
-    mkpath(resdir_json)
+    no_json = get(config, "no_json", false)
+
+    if !no_json
+        resdir_json = joinpath(config["export_dir"], "res_json")
+        mkpath(resdir_json)
+    else
+        D = OPFGenerator.initialize_res(config)
+    end
 
     # Dummy run (for pre-compilation)
     data0 = make_basic_network(pglib("14_ieee"))
@@ -108,11 +114,25 @@ if abspath(PROGRAM_FILE) == @__FILE__
         tgen = @elapsed data_ = rand(rng, opf_sampler)
         tsolve = @elapsed d = main(data_, config)
         d["meta"]["seed"] = s
-        twrite = @elapsed save_json(joinpath(resdir_json, config["ref"] * "_s$s.json.gz"), d)
+
+        if !no_json
+            twrite = @elapsed save_json(joinpath(resdir_json, config["ref"] * "_s$s.json.gz"), d)
+        else
+            twrite = @elapsed OPFGenerator.add_datapoint!(D, d)
+        end
+
         @info "Seed $s" tgen tsolve twrite
     end
 
     @info "All instances completed."
+
+    if no_json
+        tconvert = @elapsed OPFGenerator.convert_to_h5!(D)
+        filepath = joinpath(config["export_dir"], "res_h5", caseref * "_s$smin-s$smax.h5")
+        mkpath(dirname(filepath))
+        th5write = @elapsed OPFGenerator.save_h5(filepath, D)
+        @info "Wrote HDF5 to $filepath" tconvert th5write
+    end
 
     return nothing
 end

--- a/src/opf/acp.jl
+++ b/src/opf/acp.jl
@@ -244,9 +244,9 @@ function json2h5(::Type{PM.ACPPowerModel}, res)
 
     res_h5 = Dict{String,Any}(
         "meta" => Dict{String,Any}(
-            "termination_status" => res["termination_status"],
-            "primal_status" => res["primal_status"],
-            "dual_status" => res["dual_status"],
+            "termination_status" => string(res["termination_status"]),
+            "primal_status" => string(res["primal_status"]),
+            "dual_status" => string(res["dual_status"]),
             "solve_time" => res["solve_time"],
         ),
     )

--- a/src/opf/dcp.jl
+++ b/src/opf/dcp.jl
@@ -200,9 +200,9 @@ function json2h5(::Type{PM.DCPPowerModel}, res)
 
     res_h5 = Dict{String,Any}(
         "meta" => Dict{String,Any}(
-            "termination_status" => res["termination_status"],
-            "primal_status" => res["primal_status"],
-            "dual_status" => res["dual_status"],
+            "termination_status" => string(res["termination_status"]),
+            "primal_status" => string(res["primal_status"]),
+            "dual_status" => string(res["dual_status"]),
             "solve_time" => res["solve_time"],
         ),
     )

--- a/src/opf/socwr.jl
+++ b/src/opf/socwr.jl
@@ -321,9 +321,9 @@ function json2h5(::Type{OPF}, res) where{OPF <: Union{PM.SOCWRPowerModel,PM.SOCW
 
     res_h5 = Dict{String,Any}(
         "meta" => Dict{String,Any}(
-            "termination_status" => res["termination_status"],
-            "primal_status" => res["primal_status"],
-            "dual_status" => res["dual_status"],
+            "termination_status" => string(res["termination_status"]),
+            "primal_status" => string(res["primal_status"]),
+            "dual_status" => string(res["dual_status"]),
             "solve_time" => res["solve_time"],
         ),
     )


### PR DESCRIPTION
This requires each `sampler.jl` job to have enough memory to store all the results, but saves disk space and a bit of time in the `merge` job. The option is disabled by default.