### PR TITLE
Additional tests for dual objective value

### DIFF
--- a/test/opf/dcp.jl
+++ b/test/opf/dcp.jl
@@ -23,6 +23,7 @@ function test_opf_pm(::Type{PM.DCPPowerModel}, data::Dict)
     @test res["dual_status"] == FEASIBLE_POINT
     # Check objective value against PowerModels
     @test isapprox(res["objective"], res_pm["objective"], atol=1e-6, rtol=1e-6)
+    @test isapprox(res["objective"], res["objective_lb"], rtol=1e-6)
 
     # Force PM solution into our model, and check that the solution is feasible
     # TODO: use JuMP.primal_feasibility_report instead

--- a/test/opf/socwr.jl
+++ b/test/opf/socwr.jl
@@ -25,6 +25,11 @@ function test_opf_pm(::Type{OPF}, data::Dict) where {OPF <: SOCWRPowerModel}
     @test res["dual_status"] == FEASIBLE_POINT
     # ⚠ we do not check against PowerModels' objective value, 
     #   because our SOC formulation is not equivalent
+    # Check that primal/dual objectives are matching only for conic form
+    #   (Ipopt is not good with dual objective value)
+    if OPF == PM.SOCWRConicPowerModel
+        @test isapprox(res["objective"], res["objective_lb"], rtol=1e-6)
+    end
 
     # Force PM solution into our model, and check that the solution is feasible
     # TODO: use JuMP.primal_feasibility_report instead


### PR DESCRIPTION
Added unit tests following #73.
Nothing fancy, I only check that primal/dual values are consistent for convex conic (`SOCWRConic` and `DCP`) problems.
I have found that the dual objective value returned by Ipopt does not match the primal when solving `SOCWR` problems, so I removed that test.