### PR TITLE
Add SLOW_PROGRESS as a feasible termination status in merge.jl

### DIFF
--- a/slurm/merge.jl
+++ b/slurm/merge.jl
@@ -70,7 +70,7 @@ function main(config::Dict)
                 n_samples = length(read(f["termination_status"]))
                 feasible = trues(n_samples)
             end
-            feasible .&= (read(f["termination_status"]) .== "OPTIMAL") .| (read(f["termination_status"]) .== "LOCALLY_SOLVED")
+            feasible .&= (read(f["termination_status"]) .== "OPTIMAL") .| (read(f["termination_status"]) .== "LOCALLY_SOLVED") .| (read(f["termination_status"]) .== "SLOW_PROGRESS")
             feasible .&= (read(f["primal_status"]) .== "FEASIBLE_POINT")
             feasible .&= (read(f["dual_status"]) .== "FEASIBLE_POINT")
         end


### PR DESCRIPTION
Mosek will often return solutions with termination status `SLOW_PROGRESS` for `SparseSDPOPF` instances, even though this does not mean the solution quality is unacceptable.

For reference, among ~50k problem parameters, `SOCOPF` instances were all solved to `OPTIMAL` by Mosek, while only ~700 out of all the `SparseSDPOPF` instances were solved to `OPTIMAL`. The remaining ones that were not infeasible were all `SLOW_PROGRESS`.

The primal status and dual status still need to be `FEASIBLE_POINT`.