### PR TITLE
Modify HSL code in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ The recommended solver for Ipopt is `ma27`.
 ```toml
 solver.name = "Ipopt"
 solver.attributes.linear_solver = "ma27"
+solver.attributes.hsllib = HSL_jll.libhsl_path
 ```
 
 ## Quick start


### PR DESCRIPTION
The code example in README for using HSL for Ipopt is missing a line that sets the HSL_jll path for Ipopt. For example, see
https://github.com/AI4OPT/PGLearn.jl/blob/59938b95c1116f72c3f7763ee0f1eb392dcb7028/exp/sampler.jl#L81
or in fact refer to [Ipopt.jl installation instructions](https://github.com/jump-dev/Ipopt.jl?tab=readme-ov-file#linear-solvers).